### PR TITLE
fix: skip run instead of dying when job deadline cannot fit the work

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hwm_worker (1.3.1)
+    hwm_worker (1.3.2)
       capybara (~> 3.40)
       rest-client
       rollbar

--- a/lib/config/initializers.rb
+++ b/lib/config/initializers.rb
@@ -5,7 +5,11 @@ $stderr.sync = true
 require 'capybara'
 require 'rollbar'
 require 'config/secrets'
+require 'helpers/deadline'
 require 'selenium/webdriver'
+
+# Start the job budget clock as early as possible.
+Deadline.start!
 
 Rollbar.configure do |config|
   config.access_token = SECRETS['rollbar']['token']

--- a/lib/helpers/captcha/resolver.rb
+++ b/lib/helpers/captcha/resolver.rb
@@ -1,4 +1,5 @@
 require 'helpers/captcha/request'
+require 'helpers/deadline'
 require 'helpers/work_logger'
 
 module Captcha
@@ -13,6 +14,7 @@ module Captcha
     MAX_ATTEMPTS = 18
 
     CaptchaExceededMaxAttempts = Class.new(StandardError)
+    CaptchaDeadlineExceeded = Class.new(StandardError)
 
     attr_reader :solved_text, :base64_captcha
 
@@ -25,13 +27,32 @@ module Captcha
       request.solve
 
       attempts = 0
+      started_at = Deadline.elapsed
+
+      WorkLogger.current.info { "captcha submitted budget_left=#{Deadline.left_for_log}" }
 
       begin
         attempts += 1
         sleep POLL_INTERVAL
-        request.fetch.json_response['request']
+        solved = request.fetch.json_response['request']
+
+        WorkLogger.current.info do
+          "captcha solved attempts=#{attempts} took=#{Deadline.elapsed - started_at}s " \
+            "budget_left=#{Deadline.left_for_log}"
+        end
+
+        solved
       rescue Captcha::Request::CaptchaNotResolved
-        raise CaptchaExceededMaxAttempts if attempts >= MAX_ATTEMPTS
+        if attempts >= MAX_ATTEMPTS
+          raise CaptchaExceededMaxAttempts,
+                "captcha unsolved after #{attempts} attempts over #{Deadline.elapsed - started_at}s"
+        end
+
+        if Deadline.exceeded?
+          raise CaptchaDeadlineExceeded,
+                "gave up polling rucaptcha after #{attempts} attempts over " \
+                "#{Deadline.elapsed - started_at}s, job budget exhausted"
+        end
 
         WorkLogger.current.debug { "captcha not resolved yet, attempt #{attempts}/#{MAX_ATTEMPTS}" }
         retry

--- a/lib/helpers/deadline.rb
+++ b/lib/helpers/deadline.rb
@@ -1,0 +1,76 @@
+##
+# Tracks how much wall clock the process is still allowed to burn.
+#
+# Kubernetes counts activeDeadlineSeconds from Job creation, not from the
+# moment ruby boots, so DEADLINE_SECONDS is expected to be activeDeadlineSeconds
+# already discounted by pod scheduling and selenium warmup.
+#
+# Unset (or 0) means no budget tracking, which is what local runs want.
+#
+module Deadline
+  extend self
+
+  BUDGET = Integer(ENV.fetch('DEADLINE_SECONDS', 0))
+
+  # Left free at the end so a doomed step reports itself instead of being
+  # SIGTERMed halfway through a form submit.
+  RESERVE = 20
+
+  ##
+  # Freeze the start of the budget. Called once during boot.
+  #
+  def start!
+    @started_at = monotonic
+    self
+  end
+
+  def unlimited?
+    BUDGET.zero?
+  end
+
+  ##
+  # Seconds still available before RESERVE kicks in. Can go negative.
+  #
+  def left
+    return Float::INFINITY if unlimited?
+
+    start! if @started_at.nil?
+
+    BUDGET - RESERVE - (monotonic - @started_at)
+  end
+
+  def exceeded?
+    left <= 0
+  end
+
+  ##
+  # Seconds burned since boot, for phase timing in logs.
+  #
+  def elapsed
+    start! if @started_at.nil?
+
+    (monotonic - @started_at).round
+  end
+
+  ##
+  # Remaining budget rendered for logs, since left is Infinity when unlimited.
+  #
+  def left_for_log
+    remaining = left
+
+    remaining.infinite? ? 'unlimited' : "#{remaining.round}s"
+  end
+
+  ##
+  # Test seam, also lets bin/hunt and bin/run share the module safely.
+  #
+  def reset!
+    @started_at = nil
+  end
+
+  private
+
+  def monotonic
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+end

--- a/lib/helpers/work_time.rb
+++ b/lib/helpers/work_time.rb
@@ -7,16 +7,19 @@ module WorkTime
   HOUR = 60 * 60
   DELTA = 10 # if some calculation went wrong on writing working time
   HAUNT_MAX_WAIT = 100
-  MAX_SLEEP = Integer(ENV.fetch('MAX_SLEEP_SECONDS', 240)) # DO NOT CHANGE, SHOULD BE IN SYNC WITH kubernetes.activeDeadlineSeconds
 
   ##
-  # Define time to sleep for worker + DELTA (ocasionally time)
+  # Full time left on the 1 hour cooldown + DELTA (ocasionally time).
+  #
+  # Deliberately uncapped: a capped wait used to wake the worker up before the
+  # cooldown expired, which lands on a page with no job form. Runner compares
+  # this against Deadline.left and skips the run when it does not fit.
   #
   def wait_time(user_id)
     return 0 if FileBase.last_work(user_id).nil?
 
     time_to_wait = (FileBase.last_work(user_id).to_i + HOUR) - Time.now.to_i
-    [time_to_wait.negative? ? 0 : time_to_wait + DELTA, MAX_SLEEP].min
+    time_to_wait.negative? ? 0 : time_to_wait + DELTA
   end
 
   def hunt_wait_time

--- a/lib/hwm_worker/runner.rb
+++ b/lib/hwm_worker/runner.rb
@@ -1,28 +1,62 @@
 require 'hwm_worker/login'
 require 'hwm_worker/work'
 require 'helpers/work_time'
+require 'helpers/deadline'
 require 'models/user'
 
 class Runner
+  # Worst case cost of login, navigation and the captcha round trip. If the
+  # cooldown sleep would not leave this much, the run cannot finish and is
+  # skipped instead of getting SIGTERMed mid-submit.
+  WORK_BUDGET = 300
+
   def self.call(user:)
     new(user).call
   end
 
   def call
     wait = WorkTime.wait_time(user.id)
+
+    log_phase('start', "cooldown_wait=#{wait}s work_budget=#{WORK_BUDGET}s")
+
+    if wait + WORK_BUDGET > Deadline.left
+      log_phase('skip', "reason=budget cooldown_wait=#{wait}s work_budget=#{WORK_BUDGET}s")
+      return
+    end
+
     WorkLogger.current.info { "Sleeping for #{wait}." }
     sleep wait
+    log_phase('slept', "cooldown_wait=#{wait}s")
 
     WorkLogger.current.info { "Try to login with #{user.login}" }
     Login.call(session: session, user: user)
+    log_phase('login_done')
 
     WorkLogger.current.info { "Try to apply for a job with #{user.login}" }
     Work.call(session: session, user: user)
+    log_phase('done', 'outcome=applied')
+  rescue StandardError => e
+    log_phase('done', "outcome=failed error=#{e.class}")
+    raise
   end
 
   private
 
   attr_reader :session, :user
+
+  ##
+  # One greppable line per phase so runs can be compared over time:
+  #   run phase=login_done user=xa4ba4 elapsed=95s budget_left=525s
+  #
+  def log_phase(phase, extra = nil)
+    WorkLogger.current.info do
+      [
+        "run phase=#{phase} user=#{user.login}",
+        "elapsed=#{Deadline.elapsed}s budget_left=#{Deadline.left_for_log}",
+        extra,
+      ].compact.join(' ')
+    end
+  end
 
   def initialize(user)
     session_mode = SECRETS['capybara']['session'].to_sym || :selenium_chrome_headless

--- a/lib/hwm_worker/version.rb
+++ b/lib/hwm_worker/version.rb
@@ -1,3 +1,3 @@
 module HwmWorker
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/lib/hwm_worker/work.rb
+++ b/lib/hwm_worker/work.rb
@@ -1,6 +1,8 @@
 require 'config/urls'
 require 'helpers/captcha/main'
+require 'helpers/deadline'
 require 'helpers/file_base'
+require 'helpers/work_time'
 
 ##
 # Find available work
@@ -23,8 +25,10 @@ module Work
   def apply_work(session, user)
     captcha_el = session.find('[name="work"] img.getjob_capcha')
 
+    WorkLogger.current.info { "apply user=#{user.login} branch=captcha budget_left=#{Deadline.left_for_log}" }
     apply_work_with_captcha(session, user, captcha_el)
   rescue Capybara::ElementNotFound
+    WorkLogger.current.info { "apply user=#{user.login} branch=manual budget_left=#{Deadline.left_for_log}" }
     apply_work_without_captcha(session, user)
   end
 
@@ -32,6 +36,7 @@ module Work
     session.find('input.getjob_submitBtn').click
     WorkLogger.current.info { "#{user.login} successfully applied for a job. Wait hour." }
     log_gold(session, user)
+    log_interval(user)
     Rollbar.info("#{user.login} successfully applied for a job.")
     FileBase.write_last_work(user.id)
   rescue Capybara::ElementNotFound => e
@@ -48,10 +53,29 @@ module Work
 
     WorkLogger.current.info { "#{user.login} successfully applied for a job. Wait hour." }
     log_gold(session, user)
+    log_interval(user)
     Rollbar.info("#{user.login} successfully applied for a job.")
     FileBase.write_last_work(user.id)
   rescue Capybara::ElementNotFound => e
     raise CannotApplyForJobError, "Cannot apply for job (with captcha): #{e.message}"
+  end
+
+  ##
+  # Gap between this application and the previous one. Should sit just above
+  # HOUR; a much larger gap means an hourly run was skipped or failed.
+  #
+  def log_interval(user)
+    last_work = FileBase.last_work(user.id)
+
+    if last_work.nil?
+      WorkLogger.current.info { "applied user=#{user.login} interval=none" }
+      return
+    end
+
+    interval = Time.now.to_i - last_work.to_i
+    WorkLogger.current.info do
+      "applied user=#{user.login} interval=#{interval}s over_cooldown=#{interval - WorkTime::HOUR}s"
+    end
   end
 
   def log_gold(session, user)

--- a/spec/helpers/captcha/resolver_spec.rb
+++ b/spec/helpers/captcha/resolver_spec.rb
@@ -122,6 +122,43 @@ RSpec.describe Captcha::Resolver do
       end
     end
 
+    context 'when the job budget runs out mid poll' do
+      before do
+        allow(mock_request).to receive(:solve).and_return(mock_request)
+        allow(mock_request).to receive(:fetch).and_raise(Captcha::Request::CaptchaNotResolved)
+      end
+
+      it 'gives up on the first retry instead of waiting for SIGTERM' do
+        allow(Deadline).to receive(:exceeded?).and_return(true)
+
+        expect { resolver.call }.to raise_error(described_class::CaptchaDeadlineExceeded, /after 1 attempts/)
+        expect(mock_request).to have_received(:fetch).once
+      end
+
+      it 'keeps polling until the budget is actually gone' do
+        allow(Deadline).to receive(:exceeded?).and_return(false, false, true)
+
+        expect { resolver.call }.to raise_error(described_class::CaptchaDeadlineExceeded, /after 3 attempts/)
+        expect(mock_request).to have_received(:fetch).exactly(3).times
+      end
+
+      it 'still prefers MAX_ATTEMPTS when the budget never runs out' do
+        allow(Deadline).to receive(:exceeded?).and_return(false)
+
+        expect { resolver.call }.to raise_error(described_class::CaptchaExceededMaxAttempts)
+      end
+    end
+
+    describe 'CaptchaDeadlineExceeded' do
+      it 'is a StandardError so HwmWorker.run reports it' do
+        expect(described_class::CaptchaDeadlineExceeded.ancestors).to include(StandardError)
+      end
+
+      it 'is distinct from CaptchaExceededMaxAttempts' do
+        expect(described_class::CaptchaDeadlineExceeded).not_to eq(described_class::CaptchaExceededMaxAttempts)
+      end
+    end
+
     context 'when the last poll succeeds' do
       before do
         allow(mock_request).to receive(:solve).and_return(mock_request)

--- a/spec/helpers/deadline_spec.rb
+++ b/spec/helpers/deadline_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+require 'helpers/deadline'
+
+RSpec.describe Deadline do
+  before { described_class.reset! }
+
+  after { described_class.reset! }
+
+  def stub_budget(seconds)
+    stub_const('Deadline::BUDGET', seconds)
+  end
+
+  def stub_elapsed(seconds)
+    start = 1000.0
+    allow(described_class).to receive(:monotonic).and_return(start, start + seconds)
+  end
+
+  describe '.unlimited?' do
+    it 'is true when budget is zero' do
+      stub_budget(0)
+      expect(described_class).to be_unlimited
+    end
+
+    it 'is false when budget is set' do
+      stub_budget(600)
+      expect(described_class).not_to be_unlimited
+    end
+  end
+
+  describe '.left' do
+    it 'is infinite when unlimited' do
+      stub_budget(0)
+      expect(described_class.left).to eq(Float::INFINITY)
+    end
+
+    it 'subtracts elapsed time and RESERVE from the budget' do
+      stub_budget(600)
+      stub_elapsed(100)
+      described_class.start!
+
+      expect(described_class.left).to eq(600 - Deadline::RESERVE - 100)
+    end
+
+    it 'starts the clock lazily when start! was never called' do
+      stub_budget(600)
+      allow(described_class).to receive(:monotonic).and_return(1000.0)
+
+      expect(described_class.left).to eq(600 - Deadline::RESERVE)
+    end
+
+    it 'goes negative once the budget is blown' do
+      stub_budget(100)
+      stub_elapsed(500)
+      described_class.start!
+
+      expect(described_class.left).to eq(100 - Deadline::RESERVE - 500)
+    end
+  end
+
+  describe '.elapsed' do
+    it 'reports whole seconds since the clock started' do
+      stub_elapsed(42.4)
+      described_class.start!
+
+      expect(described_class.elapsed).to eq(42)
+    end
+
+    it 'works without a configured budget' do
+      stub_budget(0)
+      stub_elapsed(7.6)
+      described_class.start!
+
+      expect(described_class.elapsed).to eq(8)
+    end
+
+    it 'is 0 when the clock was never started' do
+      allow(described_class).to receive(:monotonic).and_return(1000.0)
+
+      expect(described_class.elapsed).to eq(0)
+    end
+  end
+
+  describe '.left_for_log' do
+    it 'renders remaining seconds with a unit' do
+      stub_budget(600)
+      stub_elapsed(100)
+      described_class.start!
+
+      expect(described_class.left_for_log).to eq("#{600 - Deadline::RESERVE - 100}s")
+    end
+
+    it 'renders negative budget rather than clamping' do
+      stub_budget(60)
+      stub_elapsed(200)
+      described_class.start!
+
+      expect(described_class.left_for_log).to eq("#{60 - Deadline::RESERVE - 200}s")
+    end
+
+    it 'renders unlimited instead of Infinity' do
+      stub_budget(0)
+
+      expect(described_class.left_for_log).to eq('unlimited')
+    end
+  end
+
+  describe '.exceeded?' do
+    it 'is false while budget remains' do
+      stub_budget(600)
+      stub_elapsed(10)
+      described_class.start!
+
+      expect(described_class).not_to be_exceeded
+    end
+
+    it 'is true once only RESERVE is left' do
+      stub_budget(600)
+      stub_elapsed(600 - Deadline::RESERVE)
+      described_class.start!
+
+      expect(described_class).to be_exceeded
+    end
+
+    it 'is true past the budget' do
+      stub_budget(60)
+      stub_elapsed(120)
+      described_class.start!
+
+      expect(described_class).to be_exceeded
+    end
+
+    it 'is never true when unlimited' do
+      stub_budget(0)
+      expect(described_class).not_to be_exceeded
+    end
+  end
+end

--- a/spec/helpers/work_time_spec.rb
+++ b/spec/helpers/work_time_spec.rb
@@ -30,14 +30,13 @@ RSpec.describe WorkTime do
           allow(FileBase).to receive(:last_work).with(user_id).and_return(last_work_time.to_s)
         end
 
-        it 'returns remaining time plus DELTA, capped at MAX_SLEEP' do
+        it 'returns remaining time plus DELTA' do
           expected_wait = (last_work_time + WorkTime::HOUR) - current_time.to_i
-          expect(described_class.wait_time(user_id)).to eq([expected_wait + WorkTime::DELTA, WorkTime::MAX_SLEEP].min)
+          expect(described_class.wait_time(user_id)).to eq(expected_wait + WorkTime::DELTA)
         end
 
-        it 'calculates correct wait time (30 minutes remaining, capped)' do
-          # 1800 + 10 = 1810, but capped at MAX_SLEEP (240)
-          expect(described_class.wait_time(user_id)).to eq(WorkTime::MAX_SLEEP)
+        it 'calculates correct wait time (30 minutes remaining)' do
+          expect(described_class.wait_time(user_id)).to eq(1800 + WorkTime::DELTA)
         end
       end
 
@@ -72,8 +71,8 @@ RSpec.describe WorkTime do
           allow(FileBase).to receive(:last_work).with(user_id).and_return(last_work_time.to_s)
         end
 
-        it 'returns MAX_SLEEP (full hour would exceed cap)' do
-          expect(described_class.wait_time(user_id)).to eq(WorkTime::MAX_SLEEP)
+        it 'returns the full hour plus DELTA, uncapped' do
+          expect(described_class.wait_time(user_id)).to eq(WorkTime::HOUR + WorkTime::DELTA)
         end
       end
 
@@ -84,9 +83,8 @@ RSpec.describe WorkTime do
           allow(FileBase).to receive(:last_work).with(user_id).and_return(last_work_time.to_s)
         end
 
-        it 'returns MAX_SLEEP when last_work is in future (exceeds cap)' do
-          # time_to_wait = 3700 + 10 = 3710, capped at MAX_SLEEP
-          expect(described_class.wait_time(user_id)).to eq(WorkTime::MAX_SLEEP)
+        it 'returns more than an hour when last_work is in the future' do
+          expect(described_class.wait_time(user_id)).to eq(WorkTime::HOUR + 100 + WorkTime::DELTA)
         end
       end
     end

--- a/spec/hwm_worker/runner_spec.rb
+++ b/spec/hwm_worker/runner_spec.rb
@@ -1,0 +1,157 @@
+require 'spec_helper'
+require 'hwm_worker/runner'
+require 'helpers/deadline'
+
+RSpec.describe Runner do
+  let(:user) { instance_double('User', id: 'test_user', login: 'xa4ba4') }
+  let(:session) { instance_double(Capybara::Session) }
+  let(:runner) { described_class.allocate }
+  let(:logged_lines) { [] }
+  # Logger takes the message as a block, so capture the rendered strings.
+  let(:logger) do
+    lines = logged_lines
+    Class.new do
+      define_method(:info) { |message = nil, &block| lines << (block ? block.call : message) }
+      alias_method :debug, :info
+      alias_method :fatal, :info
+    end.new
+  end
+
+  before do
+    runner.instance_variable_set(:@user, user)
+    runner.instance_variable_set(:@session, session)
+    allow(WorkLogger).to receive(:current).and_return(logger)
+    allow(runner).to receive(:sleep)
+  end
+
+  describe '#call' do
+    context 'when the cooldown sleep plus work fits the remaining budget' do
+      before do
+        allow(WorkTime).to receive(:wait_time).with('test_user').and_return(240)
+        allow(Deadline).to receive(:left).and_return(240 + Runner::WORK_BUDGET + 1)
+      end
+
+      it 'sleeps and runs login and work' do
+        expect(runner).to receive(:sleep).with(240)
+        expect(Login).to receive(:call).with(session: session, user: user)
+        expect(Work).to receive(:call).with(session: session, user: user)
+
+        runner.call
+      end
+
+      it 'logs every phase in order with budget context' do
+        allow(Login).to receive(:call)
+        allow(Work).to receive(:call)
+
+        runner.call
+
+        phases = logged_lines.grep(/^run phase=/).map { |line| line[/phase=(\w+)/, 1] }
+        expect(phases).to eq(%w[start slept login_done done])
+        expect(logged_lines).to include(
+          a_string_including('run phase=done', 'outcome=applied', 'budget_left=541s')
+        )
+      end
+    end
+
+    context 'when work raises' do
+      before do
+        allow(WorkTime).to receive(:wait_time).with('test_user').and_return(0)
+        allow(Deadline).to receive(:left).and_return(600)
+        allow(Login).to receive(:call)
+        allow(Work).to receive(:call).and_raise(Work::CannotApplyForJobError, 'no form')
+      end
+
+      it 'logs the failed outcome and re-raises' do
+        expect { runner.call }.to raise_error(Work::CannotApplyForJobError)
+
+        expect(logged_lines).to include(
+          a_string_including('run phase=done', 'outcome=failed', 'error=Work::CannotApplyForJobError')
+        )
+      end
+    end
+
+    context 'when the sleep would eat the whole budget' do
+      before do
+        allow(WorkTime).to receive(:wait_time).with('test_user').and_return(240)
+        allow(Deadline).to receive(:left).and_return(260)
+      end
+
+      it 'skips without touching the browser' do
+        expect(runner).not_to receive(:sleep)
+        expect(Login).not_to receive(:call)
+        expect(Work).not_to receive(:call)
+
+        runner.call
+      end
+
+      it 'logs why the run was skipped' do
+        runner.call
+
+        expect(logged_lines).to include(
+          a_string_including('run phase=skip', 'user=xa4ba4', 'reason=budget', 'cooldown_wait=240s', 'budget_left=260s')
+        )
+      end
+
+      it 'does not log a login or done phase' do
+        runner.call
+
+        expect(logged_lines).not_to include(a_string_including('phase=login_done'))
+        expect(logged_lines).not_to include(a_string_including('phase=done'))
+      end
+    end
+
+    context 'when there is exactly enough budget' do
+      before do
+        allow(WorkTime).to receive(:wait_time).with('test_user').and_return(100)
+        allow(Deadline).to receive(:left).and_return(100 + Runner::WORK_BUDGET)
+      end
+
+      it 'proceeds, RESERVE already covers the boundary' do
+        expect(Login).to receive(:call)
+        expect(Work).to receive(:call)
+
+        runner.call
+      end
+    end
+
+    context 'when one second short of enough budget' do
+      before do
+        allow(WorkTime).to receive(:wait_time).with('test_user').and_return(100)
+        allow(Deadline).to receive(:left).and_return(100 + Runner::WORK_BUDGET - 1)
+      end
+
+      it 'skips' do
+        expect(Login).not_to receive(:call)
+
+        runner.call
+      end
+    end
+
+    context 'when no cooldown is pending but the budget is already blown' do
+      before do
+        allow(WorkTime).to receive(:wait_time).with('test_user').and_return(0)
+        allow(Deadline).to receive(:left).and_return(-5.0)
+      end
+
+      it 'skips' do
+        expect(Login).not_to receive(:call)
+
+        runner.call
+      end
+    end
+
+    context 'when running without a budget' do
+      before do
+        allow(WorkTime).to receive(:wait_time).with('test_user').and_return(240)
+        allow(Deadline).to receive(:left).and_return(Float::INFINITY)
+      end
+
+      it 'always proceeds' do
+        expect(Login).to receive(:call)
+        expect(Work).to receive(:call)
+
+        runner.call
+      end
+    end
+  end
+end

--- a/spec/hwm_worker/work_spec.rb
+++ b/spec/hwm_worker/work_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'hwm_worker/work'
+
+RSpec.describe Work do
+  let(:user) { instance_double('User', id: 'test_user', login: 'xa4ba4') }
+  let(:logged_lines) { [] }
+  let(:logger) do
+    lines = logged_lines
+    Class.new do
+      define_method(:info) { |message = nil, &block| lines << (block ? block.call : message) }
+      alias_method :debug, :info
+    end.new
+  end
+
+  before { allow(WorkLogger).to receive(:current).and_return(logger) }
+
+  describe 'interval logging' do
+    let(:now) { Time.now }
+
+    before { allow(Time).to receive(:now).and_return(now) }
+
+    context 'when a previous application is recorded' do
+      it 'reports the gap and how far past the cooldown it landed' do
+        allow(FileBase).to receive(:last_work).with('test_user').and_return((now.to_i - 3712).to_s)
+
+        described_class.send(:log_interval, user)
+
+        expect(logged_lines).to include('applied user=xa4ba4 interval=3712s over_cooldown=112s')
+      end
+
+      it 'reports a negative over_cooldown when applied too early' do
+        allow(FileBase).to receive(:last_work).with('test_user').and_return((now.to_i - 3400).to_s)
+
+        described_class.send(:log_interval, user)
+
+        expect(logged_lines).to include('applied user=xa4ba4 interval=3400s over_cooldown=-200s')
+      end
+
+      it 'reports a large gap when hourly runs were skipped' do
+        allow(FileBase).to receive(:last_work).with('test_user').and_return((now.to_i - 7300).to_s)
+
+        described_class.send(:log_interval, user)
+
+        expect(logged_lines).to include('applied user=xa4ba4 interval=7300s over_cooldown=3700s')
+      end
+    end
+
+    context 'when nothing was ever recorded' do
+      it 'does not blow up on nil' do
+        allow(FileBase).to receive(:last_work).with('test_user').and_return(nil)
+
+        expect { described_class.send(:log_interval, user) }.not_to raise_error
+        expect(logged_lines).to include('applied user=xa4ba4 interval=none')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Kubernetes counts activeDeadlineSeconds from Job creation, so the cooldown sleep plus login and the rucaptcha round trip could exceed it and the pod was SIGTERMed mid-submit. Track the remaining budget, skip the run when it cannot fit, and bound captcha polling by it. Drop the MAX_SLEEP cap, which truncated the cooldown wait and woke the worker before the job form was available. Log one phase line per stage plus the interval between applications.